### PR TITLE
feat: Phase 1/2 completion, diagram UX & results panel improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 // src/App.tsx
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import { useStore } from './store'
 import { computeCutPlan } from './algorithm/guillotine'
 import { MAX_TOTAL_PIECES } from './constants'
@@ -10,6 +10,12 @@ import DiagramPanel from './components/DiagramPanel'
 import ResultsPanel from './components/ResultsPanel'
 import MobileTabBar from './components/MobileTabBar'
 import type { CutPlan } from './types'
+
+export interface PieceHighlight {
+  plateNumber: number   // 1-based plate number
+  pieceX: number        // algorithm-space x of placement
+  pieceY: number        // algorithm-space y of placement
+}
 
 type Tab = 'eingabe' | 'diagramm' | 'ergebnis'
 
@@ -36,6 +42,8 @@ function EmptyResultsState() {
 export default function App() {
   const [plan, setPlan] = useState<CutPlan | null>(null)
   const [activeTab, setActiveTab] = useState<Tab>('eingabe')
+  const [highlight, setHighlight] = useState<PieceHighlight | null>(null)
+  const onHighlight = useCallback((h: PieceHighlight | null) => setHighlight(h), [])
 
   const { cutPieces, stockPlates, kerf, trimLeft, trimTop } = useStore()
   const isDesktop = useMediaQuery('(min-width: 1024px)')
@@ -58,15 +66,15 @@ export default function App() {
     return (
       <div className="h-screen overflow-hidden flex flex-col">
         <Header onCompute={handleCompute} canCompute={canCompute} />
-        <div className="grid grid-cols-[420px_1fr_300px] h-[calc(100vh-52px)] overflow-hidden">
+        <div className="grid grid-cols-[420px_1fr_420px] h-[calc(100vh-52px)] overflow-hidden">
           <aside className="overflow-y-auto border-r border-slate-200 bg-white">
             <InputPanel />
           </aside>
           <main className="overflow-y-auto bg-slate-50">
-            {plan ? <DiagramPanel plan={plan} kerf={kerf} trimLeft={trimLeft} trimTop={trimTop} /> : <EmptyDiagramState />}
+            {plan ? <DiagramPanel plan={plan} kerf={kerf} trimLeft={trimLeft} trimTop={trimTop} highlight={highlight} onHighlight={onHighlight} /> : <EmptyDiagramState />}
           </main>
           <aside className="overflow-y-auto border-l border-slate-200 bg-white">
-            {plan ? <ResultsPanel plan={plan} kerf={kerf} /> : <EmptyResultsState />}
+            {plan ? <ResultsPanel plan={plan} kerf={kerf} highlight={highlight} onHighlight={onHighlight} /> : <EmptyResultsState />}
           </aside>
         </div>
       </div>
@@ -84,12 +92,12 @@ export default function App() {
         )}
         {activeTab === 'diagramm' && (
           <div className="h-full overflow-y-auto bg-slate-50">
-            {plan ? <DiagramPanel plan={plan} kerf={kerf} trimLeft={trimLeft} trimTop={trimTop} /> : <EmptyDiagramState />}
+            {plan ? <DiagramPanel plan={plan} kerf={kerf} trimLeft={trimLeft} trimTop={trimTop} highlight={highlight} onHighlight={onHighlight} /> : <EmptyDiagramState />}
           </div>
         )}
         {activeTab === 'ergebnis' && (
           <div className="h-full overflow-y-auto bg-white">
-            {plan ? <ResultsPanel plan={plan} kerf={kerf} /> : <EmptyResultsState />}
+            {plan ? <ResultsPanel plan={plan} kerf={kerf} highlight={highlight} onHighlight={onHighlight} /> : <EmptyResultsState />}
           </div>
         )}
       </div>

--- a/src/algorithm/guillotine.ts
+++ b/src/algorithm/guillotine.ts
@@ -417,6 +417,8 @@ function traverseCutTree(node: CutNode, stepCounter: { n: number }, steps: CutSt
     panelWidth: node.panelWidth,
     panelHeight: node.panelHeight,
     pieceName,
+    pieceX: node.piece?.x,
+    pieceY: node.piece?.y,
   })
   stepCounter.n++
 

--- a/src/components/CutDiagram.tsx
+++ b/src/components/CutDiagram.tsx
@@ -1,14 +1,18 @@
 // src/components/CutDiagram.tsx
 import { useRef, useState } from 'react'
 import type { PlacedPlate, CutPiece } from '../types'
+import type { PieceHighlight } from '../App'
 import { useResizeObserver } from '../hooks/useResizeObserver'
 
 interface Props {
   plate: PlacedPlate
+  plateNumber: number
   pieceColorMap: Map<string, string>
   kerf: number
   trimLeft: number
   trimTop: number
+  highlight?: PieceHighlight | null
+  onHighlight?: (h: PieceHighlight | null) => void
 }
 
 interface TooltipState {
@@ -66,7 +70,7 @@ function toDisplayRect(
   return { x: ax, y: ay, w: aw, h: ah }
 }
 
-export default function CutDiagram({ plate, pieceColorMap, kerf, trimLeft, trimTop }: Props) {
+export default function CutDiagram({ plate, plateNumber, pieceColorMap, kerf, trimLeft, trimTop, highlight, onHighlight }: Props) {
   const [scale, setScale] = useState(1)
   const [tooltip, setTooltip] = useState<TooltipState | null>(null)
   const lastDist = useRef(0)
@@ -79,7 +83,7 @@ export default function CutDiagram({ plate, pieceColorMap, kerf, trimLeft, trimT
   const svgH = transposed ? plate.stock.width : plate.stock.height
 
   // Extra margin for dimension annotations (bottom + right, in SVG units)
-  const marginBottom = 70
+  const marginBottom = 110
   const marginRight = 110
   const vbW = svgW + marginRight
   const vbH = svgH + marginBottom
@@ -200,44 +204,63 @@ export default function CutDiagram({ plate, pieceColorMap, kerf, trimLeft, trimT
             const { x: dx, y: dy, w: dw, h: dh } = toDisplayRect(p.x, p.y, pw_algo, ph_algo, transposed)
             const color = pieceColorMap.get(p.piece.id) ?? '#94a3b8'
             const labelFits = dh >= 30
-            const large = dw > 150 && dh > 80
+            const large = Math.min(dw, dh) > 80 && Math.max(dw, dh) > 150
+            const isHighlighted = highlight?.plateNumber === plateNumber && highlight?.pieceX === p.x && highlight?.pieceY === p.y
             return (
-              <g key={i} onClick={e => { e.stopPropagation(); setTooltip({ piece: p.piece }) }}
+              <g key={i}
+                onClick={e => { e.stopPropagation(); setTooltip({ piece: p.piece }); onHighlight?.({ plateNumber, pieceX: p.x, pieceY: p.y }) }}
+                onMouseEnter={() => onHighlight?.({ plateNumber, pieceX: p.x, pieceY: p.y })}
+                onMouseLeave={() => onHighlight?.(null)}
                 style={{ cursor: 'pointer' }}>
                 <rect x={dx} y={dy} width={dw} height={dh}
-                  fill={color} fillOpacity={0.8} stroke="#1e293b" strokeWidth={4} />
-                {labelFits && large && (
-                  <>
-                    <text x={dx + dw / 2} y={dy + dh / 2 - 30}
-                      textAnchor="middle" fontSize={50} fontWeight="600" fill="#1e293b">
+                  fill={color} fillOpacity={isHighlighted ? 1 : 0.8} stroke={isHighlighted ? '#2563eb' : '#1e293b'} strokeWidth={isHighlighted ? 8 : 4} />
+                {labelFits && large && (() => {
+                  const cx = dx + dw / 2
+                  const cy = dy + dh / 2
+                  const tall = dh > dw
+                  const rot = tall ? `rotate(-90, ${cx}, ${cy})` : undefined
+                  return (
+                    <>
+                      <text x={cx} y={cy - 30}
+                        textAnchor="middle" fontSize={50} fontWeight="600" fill="#1e293b"
+                        transform={rot}>
+                        {p.piece.name}
+                      </text>
+                      <text x={cx} y={cy + 30}
+                        textAnchor="middle" fontSize={40} fill="#334155"
+                        transform={rot}>
+                        {dw}×{dh}
+                      </text>
+                      {dw > 80 && (
+                        <text x={cx} y={dy + dh - 10}
+                          textAnchor="middle" fontSize={28} fill="#1e293b">
+                          {dw} mm
+                        </text>
+                      )}
+                      {dh > 80 && (
+                        <text
+                          x={dx + dw - 10} y={cy}
+                          textAnchor="middle" fontSize={28} fill="#1e293b"
+                          transform={`rotate(-90, ${dx + dw - 10}, ${cy})`}>
+                          {dh} mm
+                        </text>
+                      )}
+                    </>
+                  )
+                })()}
+                {labelFits && !large && (() => {
+                  const cx = dx + dw / 2
+                  const cy = dy + dh / 2
+                  const tall = dh > dw
+                  const rot = tall ? `rotate(-90, ${cx}, ${cy})` : undefined
+                  return (
+                    <text x={cx} y={cy}
+                      textAnchor="middle" dominantBaseline="middle" fontSize={36} fontWeight="600" fill="#1e293b"
+                      transform={rot}>
                       {p.piece.name}
                     </text>
-                    <text x={dx + dw / 2} y={dy + dh / 2 + 30}
-                      textAnchor="middle" fontSize={40} fill="#334155">
-                      {dw}×{dh}
-                    </text>
-                    {dw > 80 && (
-                      <text x={dx + dw / 2} y={dy + 28}
-                        textAnchor="middle" fontSize={28} fill="#1e293b">
-                        {dw} mm
-                      </text>
-                    )}
-                    {dh > 80 && (
-                      <text
-                        x={dx + 28} y={dy + dh / 2}
-                        textAnchor="middle" fontSize={28} fill="#1e293b"
-                        transform={`rotate(-90, ${dx + 28}, ${dy + dh / 2})`}>
-                        {dh} mm
-                      </text>
-                    )}
-                  </>
-                )}
-                {labelFits && !large && (
-                  <text x={dx + dw / 2} y={dy + dh / 2}
-                    textAnchor="middle" dominantBaseline="middle" fontSize={36} fontWeight="600" fill="#1e293b">
-                    {p.piece.name}
-                  </text>
-                )}
+                  )
+                })()}
               </g>
             )
           })}
@@ -338,7 +361,7 @@ export default function CutDiagram({ plate, pieceColorMap, kerf, trimLeft, trimT
           )}
           {/* L dimension annotation (bottom) — text centered on line */}
           {(() => {
-            const ly = svgH + 35
+            const ly = svgH + 55
             const labelText = `L ${svgW}`
             const textW = labelText.length * 20
             const gapStart = svgW / 2 - textW / 2

--- a/src/components/CutList.tsx
+++ b/src/components/CutList.tsx
@@ -1,13 +1,23 @@
 // src/components/CutList.tsx
-import { Fragment } from 'react'
+import { Fragment, useRef, useEffect } from 'react'
 import type { PlacedPlate } from '../types'
+import type { PieceHighlight } from '../App'
 import { generateCutSequence } from '../algorithm/guillotine'
 
 interface Props {
   plates: PlacedPlate[]
+  highlight?: PieceHighlight | null
+  onHighlight?: (h: PieceHighlight | null) => void
 }
 
-export default function CutList({ plates }: Props) {
+export default function CutList({ plates, highlight, onHighlight }: Props) {
+  const highlightRef = useRef<HTMLTableRowElement>(null)
+
+  useEffect(() => {
+    if (highlight && highlightRef.current) {
+      highlightRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    }
+  }, [highlight])
   // Build per-plate steps with a global counter
   const plateSteps: Array<{
     plate: PlacedPlate
@@ -58,8 +68,18 @@ export default function CutList({ plates }: Props) {
                   step.panelWidth != null && step.panelHeight != null
                     ? `${step.panelWidth}×${step.panelHeight} mm`
                     : `${plate.stock.width}×${plate.stock.height} mm`
+                const pieceName = step.pieceName
+                const isRest = pieceName?.startsWith('Rest ')
+                const hasPlacement = !isRest && step.pieceX != null && step.pieceY != null
+                const isHighlighted = hasPlacement && highlight?.plateNumber === plateNumber && highlight?.pieceX === step.pieceX && highlight?.pieceY === step.pieceY
                 return (
-                  <tr key={`step-${stepNum}`} className="border-b border-slate-50">
+                  <tr
+                    key={`step-${stepNum}`}
+                    ref={isHighlighted ? highlightRef : undefined}
+                    className={`border-b border-slate-50 ${isHighlighted ? 'bg-blue-100' : ''} ${hasPlacement ? 'cursor-pointer hover:bg-blue-50' : ''}`}
+                    onMouseEnter={hasPlacement ? () => onHighlight?.({ plateNumber, pieceX: step.pieceX!, pieceY: step.pieceY! }) : undefined}
+                    onMouseLeave={hasPlacement ? () => onHighlight?.(null) : undefined}
+                  >
                     <td className="py-1 px-2 text-slate-400">{stepNum}</td>
                     <td className="py-1 px-2 text-slate-600">{panelDims}</td>
                     <td className="py-1 px-2">
@@ -76,7 +96,7 @@ export default function CutList({ plates }: Props) {
                         mm
                       </span>
                     </td>
-                    <td className="py-1 px-2 text-slate-600">{step.pieceName ?? '—'}</td>
+                    <td className="py-1 px-2 text-slate-600">{pieceName ?? '—'}</td>
                   </tr>
                 )
               })}

--- a/src/components/DiagramPanel.tsx
+++ b/src/components/DiagramPanel.tsx
@@ -3,6 +3,7 @@ import { useState, useRef, useMemo } from 'react'
 import { COLOR_PALETTE } from '../constants'
 import CutDiagram from './CutDiagram'
 import type { CutPlan, PlacedPlate } from '../types'
+import type { PieceHighlight } from '../App'
 
 interface Props {
   plan: CutPlan
@@ -10,6 +11,8 @@ interface Props {
   trimLeft: number
   trimTop: number
   onBack?: () => void
+  highlight?: PieceHighlight | null
+  onHighlight?: (h: PieceHighlight | null) => void
 }
 
 function plateKey(plate: PlacedPlate): string {
@@ -45,7 +48,7 @@ async function exportPlateAsJpg(svgElement: SVGElement, filename: string) {
   }, 'image/jpeg', 0.92)
 }
 
-export default function DiagramPanel({ plan, kerf, trimLeft, trimTop, onBack }: Props) {
+export default function DiagramPanel({ plan, kerf, trimLeft, trimTop, onBack, highlight, onHighlight }: Props) {
   // Build color map from all placements across all plates
   const pieceColorMap = useMemo(() => {
     const map = new Map<string, string>()
@@ -211,10 +214,13 @@ export default function DiagramPanel({ plan, kerf, trimLeft, trimTop, onBack }: 
               >
                 <CutDiagram
                   plate={plate}
+                  plateNumber={idx + 1}
                   pieceColorMap={pieceColorMap}
                   kerf={kerf}
                   trimLeft={trimLeft}
                   trimTop={trimTop}
+                  highlight={highlight}
+                  onHighlight={onHighlight}
                 />
               </div>
             </div>

--- a/src/components/ResultsPanel.tsx
+++ b/src/components/ResultsPanel.tsx
@@ -1,6 +1,7 @@
 // src/components/ResultsPanel.tsx
 import { useState } from 'react'
 import type { CutPlan } from '../types'
+import type { PieceHighlight } from '../App'
 import GlobalStats from './GlobalStats'
 import SheetStats from './SheetStats'
 import CutList from './CutList'
@@ -8,6 +9,29 @@ import CutList from './CutList'
 interface Props {
   plan: CutPlan
   kerf: number
+  highlight?: PieceHighlight | null
+  onHighlight?: (h: PieceHighlight | null) => void
+}
+
+function CollapsibleHeader({
+  title,
+  open,
+  onToggle,
+}: {
+  title: string
+  open: boolean
+  onToggle: () => void
+}) {
+  return (
+    <button
+      className="w-full flex items-center justify-between px-3 py-2 text-sm font-medium text-slate-700 bg-slate-50 hover:bg-slate-100 transition-colors shrink-0"
+      onClick={onToggle}
+      aria-expanded={open}
+    >
+      <span>{title}</span>
+      <span className="text-slate-400 text-xs">{open ? '▲' : '▼'}</span>
+    </button>
+  )
 }
 
 function CollapsibleSection({
@@ -20,36 +44,44 @@ function CollapsibleSection({
   const [open, setOpen] = useState(true)
   return (
     <div className="border border-slate-200 rounded-lg overflow-hidden">
-      <button
-        className="w-full flex items-center justify-between px-3 py-2 text-sm font-medium text-slate-700 bg-slate-50 hover:bg-slate-100 transition-colors"
-        onClick={() => setOpen((o) => !o)}
-        aria-expanded={open}
-      >
-        <span>{title}</span>
-        <span className="text-slate-400 text-xs">{open ? '▲' : '▼'}</span>
-      </button>
+      <CollapsibleHeader title={title} open={open} onToggle={() => setOpen(o => !o)} />
       {open && <div className="px-3 py-2">{children}</div>}
     </div>
   )
 }
 
-export default function ResultsPanel({ plan, kerf }: Props) {
+export default function ResultsPanel({ plan, kerf, highlight, onHighlight }: Props) {
+  const [schnittfolgeOpen, setSchnittfolgeOpen] = useState(true)
+
   return (
-    <div className="flex flex-col gap-4 overflow-y-auto h-full p-4">
-      <GlobalStats plan={plan} kerf={kerf} />
+    <div className="flex flex-col gap-4 h-full p-4 overflow-hidden">
+      {/* Fixed sections */}
+      <div className="shrink-0">
+        <GlobalStats plan={plan} kerf={kerf} />
+      </div>
 
-      {plan.plates.map((plate, i) => (
-        <div key={`${plate.stock.id}-${plate.plateIndex}`} className="flex flex-col gap-2">
-          <SheetStats plate={plate} plateNumber={i + 1} />
-        </div>
-      ))}
+      <div className="shrink-0">
+        <CollapsibleSection title={`Platten (${plan.plates.length})`}>
+          <div className="flex flex-col gap-2">
+            {plan.plates.map((plate, i) => (
+              <SheetStats key={`${plate.stock.id}-${plate.plateIndex}`} plate={plate} plateNumber={i + 1} />
+            ))}
+          </div>
+        </CollapsibleSection>
+      </div>
 
-      <CollapsibleSection title="Schnittfolge">
-        <CutList plates={plan.plates} />
-      </CollapsibleSection>
+      {/* Schnittfolge fills remaining space */}
+      <div className={`min-h-0 flex flex-col border border-slate-200 rounded-lg overflow-hidden${schnittfolgeOpen ? ' flex-1' : ''}`}>
+        <CollapsibleHeader title="Schnittfolge" open={schnittfolgeOpen} onToggle={() => setSchnittfolgeOpen(o => !o)} />
+        {schnittfolgeOpen && (
+          <div className="min-h-0 flex-1 overflow-y-auto px-3 py-2">
+            <CutList plates={plan.plates} highlight={highlight} onHighlight={onHighlight} />
+          </div>
+        )}
+      </div>
 
       {plan.unplacedPieces.length > 0 && (
-        <div className="border border-red-200 bg-red-50 rounded-lg p-4">
+        <div className="shrink-0 border border-red-200 bg-red-50 rounded-lg p-4">
           <h3 className="text-sm font-semibold text-red-700 mb-2">
             Nicht platzierte Teile ({plan.unplacedPieces.length})
           </h3>

--- a/src/components/SheetStats.tsx
+++ b/src/components/SheetStats.tsx
@@ -1,6 +1,5 @@
 // src/components/SheetStats.tsx
 import type { PlacedPlate } from '../types'
-import CollapsibleSection from './CollapsibleSection'
 
 interface Props {
   plate: PlacedPlate
@@ -8,23 +7,16 @@ interface Props {
 }
 
 export default function SheetStats({ plate, plateNumber }: Props) {
-  const title = `Platte ${plateNumber} — ${plate.stock.width}×${plate.stock.height} mm`
-
   return (
-    <CollapsibleSection title={title} defaultOpen={false}>
-      <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
-        {plate.stock.label && (
-          <>
-            <dt className="text-slate-500">Bezeichnung</dt>
-            <dd className="text-slate-700 font-medium text-right">{plate.stock.label}</dd>
-          </>
-        )}
-        <dt className="text-slate-500">Teile</dt>
-        <dd className="text-slate-700 font-medium text-right">{plate.placements.length}</dd>
-
-        <dt className="text-slate-500">Verschnitt</dt>
-        <dd className="text-slate-700 font-medium text-right">{plate.wastePct.toFixed(1)} %</dd>
-      </dl>
-    </CollapsibleSection>
+    <div className="border-b border-slate-100 pb-2 last:border-b-0 last:pb-0">
+      <div className="text-xs font-medium text-slate-600 mb-1">
+        Platte {plateNumber}: {plate.stock.width}×{plate.stock.height} mm
+        {plate.stock.label ? ` — ${plate.stock.label}` : ''}
+      </div>
+      <div className="flex gap-4 text-xs text-slate-500">
+        <span>{plate.placements.length} Teile</span>
+        <span>Verschnitt {plate.wastePct.toFixed(1)}%</span>
+      </div>
+    </div>
   )
 }

--- a/src/components/StockTable.tsx
+++ b/src/components/StockTable.tsx
@@ -5,7 +5,7 @@ import type { StockPlate } from '../types'
 import { parseStockCsv } from '../utils/csvImport'
 
 const COLUMNS: Column[] = [
-  { key: 'label',     label: 'Bezeichnung', type: 'text' },
+  { key: 'label',     label: 'Bezeichnung', type: 'text', sortable: true },
   { key: 'height',    label: 'L',    type: 'number', width: '52px', sortable: true },
   { key: 'width',     label: 'B',    type: 'number', width: '52px', sortable: true },
   { key: 'thickness', label: 'D',    type: 'number', width: '40px' },

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,8 @@ export interface CutStep {
   panelWidth?: number;   // width of the panel being cut
   panelHeight?: number;  // height of the panel being cut
   pieceName?: string;    // name of the piece placed by this cut (if any)
+  pieceX?: number;       // algorithm-space x of placed piece
+  pieceY?: number;       // algorithm-space y of placed piece
 }
 
 export interface CutPlan {


### PR DESCRIPTION
## Summary
- **Phase 1 & 2 completion**: StockTable sortable label column, waste hatching, rest labels, dimension annotations all verified working
- **Diagram UX improvements**: labels rotate parallel to longest panel edge, edge measures at bottom/right, equal annotation distances, better threshold for elongated panels
- **Results panel redesign**: plates consolidated into single collapsible section, Schnittfolge fills remaining space with internal scroll, equal-width left/right panels (420px)
- **Bidirectional highlighting**: hover/click a piece in the diagram highlights its cut list row (and vice versa), using unique placement coordinates for per-panel precision with auto-scroll

## Test plan
- [x] All 18 tests pass
- [x] TypeScript compiles with zero errors
- [x] Production build succeeds
- [x] Visual verification via dev server preview
- [x] Highlighting works for individual panels in both directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)